### PR TITLE
Compatibility with macOS

### DIFF
--- a/guest
+++ b/guest
@@ -3,9 +3,12 @@ pairinguser="pairing@mumble.ugent.be"
 
 set -e
 
-abduco   > /dev/null 2>&1 || { echo 'abduco found: no' && exit 1; }
-socat -h > /dev/null 2>&1 || { echo 'socat found: no' && exit 1; }
-ssh -V   > /dev/null 2>&1 || { echo 'ssh found: no' && exit 1; }
+for COMMAND in abduco socat ssh; do
+	if ! command -v $COMMAND > /dev/null 2>&1; then
+		printf '%s found: no\n' "$COMMAND"
+		exit
+	fi
+done
 
 if ! printf '%s' "$1" | grep '^[a-z0-9-]\+$'; then
 	echo 'Please provide an alphanumeric (and -) session name'

--- a/host
+++ b/host
@@ -3,11 +3,14 @@ pairinguser="pairing@mumble.ugent.be"
 
 set -e
 
-abduco   > /dev/null 2>&1 || { echo 'abduco found: no' && exit 1; }
-socat -h > /dev/null 2>&1 || { echo 'socat found: no' && exit 1; }
-ssh -V   > /dev/null 2>&1 || { echo 'ssh found: no' && exit 1; }
-uuidgen  > /dev/null 2>&1 || { echo 'uuidgen found: no' && exit 1; }
-dvtm -v  > /dev/null 2>&1 || { echo 'dvtm found: no' && exit 1; }
+for COMMAND in abduco socat ssh uuidgen dvtm
+do
+	if ! command -v $COMMAND &> /dev/null
+	then
+		echo $COMMAND 'found: no'
+		exit
+	fi
+done
 
 # Create a temporary directory for our sockets
 umask 077

--- a/host
+++ b/host
@@ -3,11 +3,9 @@ pairinguser="pairing@mumble.ugent.be"
 
 set -e
 
-for COMMAND in abduco socat ssh uuidgen dvtm
-do
-	if ! command -v $COMMAND &> /dev/null
-	then
-		echo $COMMAND 'found: no'
+for COMMAND in abduco socat ssh uuidgen dvtm; do
+	if ! command -v $COMMAND > /dev/null 2>&1; then
+		printf '%s found: no\n' "$COMMAND"
 		exit
 	fi
 done

--- a/share
+++ b/share
@@ -3,10 +3,12 @@ shareuser="felix@mumble.ugent.be"
 
 set -e
 
-abduco   > /dev/null 2>&1 || { echo 'abduco found: no' && exit 1; }
-dvtm -v  > /dev/null 2>&1 || { echo 'dvtm found: no' && exit 1; }
-socat -h > /dev/null 2>&1 || { echo 'socat found: no' && exit 1; }
-ssh -V   > /dev/null 2>&1 || { echo 'ssh found: no' && exit 1; }
+for COMMAND in abduco socat ssh dvtm; do
+	if ! command -v $COMMAND > /dev/null 2>&1; then
+		printf '%s found: no\n' "$COMMAND"
+		exit
+	fi
+done
 
 if ! printf '%s' "$1" | grep '^[a-z0-9-]\+$'; then
 	echo 'Please provide an alphanumeric (and -) session name'


### PR DESCRIPTION
Before this change, running 'host' on macOS would result in a "found uuidgen: no" error. To reduce duplicate code, a for-loop was implemented.